### PR TITLE
Enable handling of nested lists of input/output variables and other fixes

### DIFF
--- a/chainer/graph_optimizations/static_graph.py
+++ b/chainer/graph_optimizations/static_graph.py
@@ -606,12 +606,7 @@ def static_graph(*args, **kwargs):
                 # behavior.
                 out_vars = chain.static_schedule.apply(in_vars)
 
-                if len(out_vars) == 1:
-                    out_vars, = out_vars
-
-                print("_out_vars_unflatten_inds", chain._out_vars_unflatten_inds)
                 out_vars = _unflatten_args(out_vars, chain._out_vars_unflatten_inds)
-                print("second+ iter, out_vars", len(out_vars))
 
             else:
                 # This is the first iteration. Calling the define-by-run code.
@@ -645,8 +640,6 @@ def static_graph(*args, **kwargs):
                 chain.static_schedule.create_out_arrays(tuple_out_vars)
                 backward_sched = chain.static_schedule.create_backward_schedule_func(tuple_out_vars)
                 backward_sched.create_out_arrays(in_vars)
-
-                print("first iter, out_vars", len(out_vars))
 
             return out_vars
 
@@ -682,7 +675,7 @@ def _unflatten_args(xs, inds):
     ys = []
     for ind in inds:
         code = ind[0]
-        if code == 'i':
+        if code == 's':
             return xs[0]
         elif code == 'i':
             i_start, i_end, sub_inds = ind[1:]

--- a/chainer/graph_optimizations/static_graph.py
+++ b/chainer/graph_optimizations/static_graph.py
@@ -626,11 +626,25 @@ def static_graph(*args, **kwargs):
 
                 if verbosity_level >= 2:
                     print('Creating a new backward schedule function.')
+
+                def _flatten(xs):
+                    ys = []
+                    for x in xs:
+                        if isinstance(x, (list, tuple)):
+                            x = _flatten(x)
+                        else:
+                            x = [x]
+                        ys.extend([y for y in x])
+                    return ys
+
                 # Force out_vars to be a tuple of variables.
-                if isinstance(out_vars, chainer.Variable):
-                    tuple_out_vars = out_vars,
+                if isinstance(out_vars, (list, tuple)):
+                    tuple_out_vars = _flatten(out_vars)
                 else:
-                    tuple_out_vars = out_vars
+                    tuple_out_vars = out_vars,
+                tuple_out_vars = tuple(x if isinstance(x, chainer.Variable) else
+                                       chainer.Variable(x) for x in
+                                       tuple_out_vars)
                 chain.static_schedule.create_out_arrays(tuple_out_vars)
                 backward_sched = chain.static_schedule.create_backward_schedule_func(tuple_out_vars)
                 backward_sched.create_out_arrays(in_vars)

--- a/chainer/graph_optimizations/static_graph.py
+++ b/chainer/graph_optimizations/static_graph.py
@@ -256,9 +256,10 @@ class StaticScheduleFunction(chainer.function_node.FunctionNode):
         assert len(self._in_arrays) == len(inputs)
         for n in range(len(inputs)):
             # Debug:
-            assert self._in_arrays[n].shape == inputs[n].shape
-            assert self._in_arrays[n][0].dtype == inputs[n][0].dtype
-            self._in_arrays[n][:] = inputs[n]
+            if inputs[n] is not None:
+                assert self._in_arrays[n].shape == inputs[n].shape
+                assert self._in_arrays[n][0].dtype == inputs[n][0].dtype
+                self._in_arrays[n][:] = inputs[n]
 
         # The following line should be the new performance bottleneck after the first iteration
         # has completed. Note that we have several options for the implementation:

--- a/chainer/graph_optimizations/static_graph_utilities.py
+++ b/chainer/graph_optimizations/static_graph_utilities.py
@@ -238,7 +238,7 @@ def static_forward_optimizations(func, in_vars, in_data, outputs):
                 """
                 temp_out_data = func.forward(in_data)
                 for ind, static_ar in enumerate(out_data):
-                    static_ar[:] = temp_out_data[ind]
+                    static_ar[...] = temp_out_data[ind]
 
             generic_static_forward(func, in_data, outputs)
 


### PR DESCRIPTION
This PR does the following:
*  Enables handling of nested lists of input/output variables from a wrapped `Chain`.
* Allows some variables used for the backward pass to be `None`. This is useful in e.g. multi-task networks where ground-truth might not be available for some task.
* Allow scalar arrays to be used in the static schedule. Previously, the code assumes that all learnable parameters had a shape. This PR thus allows e.g. PReLU to be used. 